### PR TITLE
Add arguments for wandb project and entity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,5 @@ cython_debug/
 
 # Dataset files
 datasets/
+
+wandb/

--- a/src/mphrqe/cli.py
+++ b/src/mphrqe/cli.py
@@ -88,6 +88,16 @@ option_use_wandb = click.option(
     "--use-wandb",
     is_flag=True,
 )
+option_wandb_project = click.option(
+    "-wp",
+    "--wandb-project",
+    default=None
+)
+option_wandb_entity = click.option(
+    "-we",
+    "--wandb-entity",
+    default=None
+)
 option_wandb_name = click.option(
     "-n",
     "--wandb-name",
@@ -276,6 +286,8 @@ def main():
 @option_num_workers
 # wandb options
 @option_use_wandb
+@option_wandb_project
+@option_wandb_entity
 @option_wandb_name
 @option_wandb_group
 # logging options
@@ -314,6 +326,8 @@ def train_cli(
     num_workers: int,
     # wandb
     use_wandb: bool,
+    wandb_project: str,
+    wandb_entity: str,
     wandb_name: str,
     wandb_group: str,
     # logging
@@ -365,6 +379,8 @@ def train_cli(
         use_wandb=use_wandb,
         wandb_name=wandb_name,
         information=information.info,
+        wandb_project=wandb_project,
+        wandb_entity=wandb_entity,
         wandb_group=wandb_group,
         is_hpo=False,
     )
@@ -433,6 +449,8 @@ def train_cli(
 @option_num_workers
 # wandb options
 @option_use_wandb
+@option_wandb_project
+@option_wandb_entity
 @option_wandb_name
 @option_wandb_group
 # evaluation options
@@ -457,6 +475,8 @@ def evaluate_cli(
     num_workers: int,
     # wandb
     use_wandb: bool,
+    wandb_project: str,
+    wandb_entity: str,
     wandb_name: str,
     wandb_group: str,
     # evaluation
@@ -520,6 +540,8 @@ def evaluate_cli(
     result_callback = init_tracker(
         config=config,
         use_wandb=use_wandb,
+        wandb_project=wandb_project,
+        wandb_entity=wandb_entity,
         wandb_name=wandb_name,
         wandb_group=wandb_group,
         information=information.info,
@@ -556,6 +578,8 @@ METRICS = {
 @option_validation_data
 @option_test_data
 @option_use_wandb
+@option_wandb_project
+@option_wandb_entity
 @option_wandb_name
 @option_num_workers
 @option_log_level
@@ -571,6 +595,8 @@ def optimize_cli(
     num_workers: int,
     # wandb options
     use_wandb: bool,
+    wandb_project: str,
+    wandb_entity: str,
     wandb_name: str,
     # logging options
     log_level: str,
@@ -586,6 +612,8 @@ def optimize_cli(
         validation_data=validation_data,
         test_data=test_data,
         use_wandb=use_wandb,
+        wandb_project=wandb_project,
+        wandb_entity=wandb_entity,
         wandb_name=wandb_name,
         num_workers=num_workers,
         num_trials=num_trials,

--- a/src/mphrqe/hpo.py
+++ b/src/mphrqe/hpo.py
@@ -41,6 +41,8 @@ class Objective:
     test_data: list[str]
 
     use_wandb: bool
+    wandb_project: str
+    wandb_entity: str
     wandb_name: Optional[str] = None
 
     # Model
@@ -165,6 +167,8 @@ class Objective:
             config=config,
             use_wandb=self.use_wandb,
             wandb_name=self.wandb_name,
+            wandb_project=self.wandb_project,
+            wandb_entity=self.wandb_entity,
             information=information.info,
             is_hpo=True,
         )
@@ -218,6 +222,8 @@ def optimize(
     validation_data: list[str],
     test_data: list[str],
     use_wandb: bool,
+    wandb_project: str,
+    wandb_entity: str,
     num_workers: int,
     num_trials: Optional[int],
     timeout: Optional[float],
@@ -282,6 +288,8 @@ def optimize(
         validation_data=validation_data,
         log_level=log_level,
         use_wandb=use_wandb,
+        wandb_project=wandb_project,
+        wandb_entity=wandb_entity,
         wandb_name=wandb_name,
         num_workers=num_workers,
         metric=metric,

--- a/src/mphrqe/tracking.py
+++ b/src/mphrqe/tracking.py
@@ -11,6 +11,8 @@ def init_tracker(
     config: Mapping[str, Any],
     use_wandb: bool,
     information: Mapping[str, Any],
+    wandb_project: str,
+    wandb_entity: str,
     wandb_name: Optional[str] = None,
     wandb_group: Optional[str] = None,
     is_hpo: bool = False,
@@ -22,12 +24,16 @@ def init_tracker(
         The configuration to log to the tracker.
     :param use_wandb:
         Whether to use wandb.
+    :param information:
+        The data information to log.
+    :param wandb_project:
+        The wandb project name.
+    :param wandb_entity:
+        The wandb entity name (e.g. username).
     :param wandb_name:
         The wandb experiment name.
     :param wandb_group:
         The wandb group name.
-    :param information:
-        The data information to log.
     :param is_hpo:
         Whether this is an HPO run and should be grouped under the wandb_name.
 
@@ -48,11 +54,12 @@ def init_tracker(
 
                     pip install wandb
             """)) from e
+
         name = wandb_name if not is_hpo else None
         group = wandb_name if is_hpo else wandb_group
         wandb_run = cast(
             wandb.wandb_sdk.wandb_run.Run,
-            wandb.init(project="stare_query", entity="hyperquery", name=name, reinit=True, group=group),
+            wandb.init(project=wandb_project, entity=wandb_entity, name=name, reinit=True, group=group),
         )
         # All wandb information needs to be collected and then stored as one action on the root of the config object.
         wandb_run.config.update(config)


### PR DESCRIPTION
`-wp` specifies wandb project, `-we` specifies the entity.